### PR TITLE
Vertical Scrolling

### DIFF
--- a/css/component.css
+++ b/css/component.css
@@ -36,6 +36,7 @@
 	height: 100%;
 	top: 0;
 	z-index: 1000;
+	overflow-y: scroll;
 }
 
 .cbp-spmenu-vertical a {


### PR DESCRIPTION
Allow scrolling in the vertical menu when there are more items than can be shown by setting overflow-y to scroll.
